### PR TITLE
Add meeting notes for April 23, 2026

### DIFF
--- a/MeetingNotes/23Apr2026.notes
+++ b/MeetingNotes/23Apr2026.notes
@@ -1,0 +1,24 @@
+Attending: R.Barnes, Jacob Haqq-Misra, Russell Deitrick     
+
+23 Apr 2026
+
+
+General updates
+
+None.
+
+Results Paper I
+
+Vidya's results are in; look good. Rory has yet to process.
+
+We have a new entrant: Avalon! JHM's simple EBM model developed with
+Claude Code. Has the Protocol v1.1 done -- will add by next month.  
+
+
+Protocol v2.0
+
+On hold.
+
+Open Discussion
+
+JHM going to AbSciCon; Rory has personal conflict so can't attend. :(


### PR DESCRIPTION
Added meeting notes from April 23, 2026, including updates on results paper and protocol status.